### PR TITLE
WIP Software Carbon Intensity (SC) implementation

### DIFF
--- a/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
@@ -4,6 +4,8 @@ import com.carbonaware.apis.CarbonAwareSdkClient;
 import com.carbonaware.apis.CarbonEmissionsParams;
 import com.carbonaware.apis.DefaultCarbonEmissionsParams;
 import com.carbonaware.endpoint.CarbonAwareActuatorEndpoint;
+import com.carbonaware.sci.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,7 +33,29 @@ public class CarbonAwareAutoConfiguration {
     }
 
     @Bean
-    public CarbonAwareActuatorEndpoint endpoint(CarbonAwareSdkClient client) {
-        return new CarbonAwareActuatorEndpoint(client);
+    public CarbonAwareActuatorEndpoint endpoint(CarbonAwareSdkClient client, SoftwareCarbonIntensityService sciService) {
+        return new CarbonAwareActuatorEndpoint(client, sciService);
+    }
+
+    @Bean
+    public SoftwareCarbonIntensityService softwareCarbonIntensityService(EnergyConsumptionProvider energyConsumptionProvider,
+                                                                         MarginalEmissionsProvider marginalEmissionsProvider,
+                                                                         EmbodiedEmissionsProvider embodiedEmissionsProvider) {
+        return new SoftwareCarbonIntensityService(energyConsumptionProvider, marginalEmissionsProvider, embodiedEmissionsProvider);
+    }
+
+    @Bean
+    public EnergyConsumptionProvider energyConsumptionProvider() {
+        return new HeuristicEnergyConsumptionProvider();
+    }
+
+    @Bean
+    public MarginalEmissionsProvider marginalEmissionsProvider(CarbonAwareSdkClient client) {
+        return new CarbonAwareSdkMarginalEmissionsProvider(client);
+    }
+
+    @Bean
+    public EmbodiedEmissionsProvider embodiedEmissionsProvider() {
+        return new ConfiguredEmboddiedEmissionsProvider();
     }
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
@@ -2,6 +2,8 @@ package com.carbonaware.endpoint;
 
 import com.carbonaware.apis.CarbonAwareSdkClient;
 import com.carbonaware.models.Emissions;
+import com.carbonaware.sci.SoftwareCarbonIntensity;
+import com.carbonaware.sci.SoftwareCarbonIntensityService;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,14 +15,21 @@ import java.util.List;
 public class CarbonAwareActuatorEndpoint {
 
     private CarbonAwareSdkClient client;
+    private SoftwareCarbonIntensityService sciService;
 
-    public CarbonAwareActuatorEndpoint(CarbonAwareSdkClient client) {
+    public CarbonAwareActuatorEndpoint(CarbonAwareSdkClient client, SoftwareCarbonIntensityService sciService) {
         this.client = client;
+        this.sciService = sciService;
     }
 
     @GetMapping("/emissions")
     public ResponseEntity<List<Emissions>> customEndPoint() {
         return new ResponseEntity<>(client.emissionsForLocation(), HttpStatus.OK);
+    }
+
+    @GetMapping("/sci")
+    public ResponseEntity<SoftwareCarbonIntensity> sciEndpoint() {
+        return new ResponseEntity<>(sciService.getSoftwareCarbonIntensity(), HttpStatus.OK);
     }
 
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/models/Emissions.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/models/Emissions.java
@@ -1,9 +1,12 @@
 package com.carbonaware.models;
 
+import java.time.ZonedDateTime;
+import java.util.Date;
+
 public class Emissions {
 
     private String location;
-    private String time;
+    private ZonedDateTime time;
     private Double rating;
     private String duration;
 
@@ -15,11 +18,11 @@ public class Emissions {
         this.location = location;
     }
 
-    public String getTime() {
+    public ZonedDateTime getTime() {
         return time;
     }
 
-    public void setTime(String time) {
+    public void setTime(ZonedDateTime time) {
         this.time = time;
     }
 

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/CarbonAwareSdkMarginalEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/CarbonAwareSdkMarginalEmissionsProvider.java
@@ -1,0 +1,45 @@
+package com.carbonaware.sci;
+
+import com.carbonaware.apis.CarbonAwareSdkClient;
+import com.carbonaware.models.Emissions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class CarbonAwareSdkMarginalEmissionsProvider implements MarginalEmissionsProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(CarbonAwareSdkMarginalEmissionsProvider.class);
+
+
+    private CarbonAwareSdkClient client;
+
+    public CarbonAwareSdkMarginalEmissionsProvider(CarbonAwareSdkClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public double getMarginalEmissions() {
+        List<Emissions> emissions = client.emissionsForLocation();
+        // sort the emissions by time, and then filter
+        final long now = System.currentTimeMillis();
+        Emissions closestEmissionsData = emissions.stream().min(new Comparator<Emissions>() {
+            public int compare(Emissions e1, Emissions e2) {
+                long diff1 = Math.abs(e1.getTime().toInstant().toEpochMilli() - now);
+                long diff2 = Math.abs(e2.getTime().toInstant().toEpochMilli() - now);
+                return Long.compare(diff1, diff2);
+            }
+        }).orElse(null);
+
+        // TODO: think about error handling for this
+        if (closestEmissionsData == null) {
+            log.error("There was a problem getting emissions data from Carbon Aware SDK");
+            return 0.0;
+        }
+
+        return closestEmissionsData.getRating();
+    }
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/ConfiguredEmboddiedEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/ConfiguredEmboddiedEmissionsProvider.java
@@ -1,0 +1,16 @@
+package com.carbonaware.sci;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class ConfiguredEmboddiedEmissionsProvider implements EmbodiedEmissionsProvider {
+
+    @Value("${spring.carbon-aware.emboddied-emissions:0.0}")
+    private double embodiedEmissions;
+
+    public ConfiguredEmboddiedEmissionsProvider() {}
+
+    @Override
+    public double getEmbodiedEmissions() {
+        return embodiedEmissions;
+    }
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/EmbodiedEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/EmbodiedEmissionsProvider.java
@@ -1,0 +1,7 @@
+package com.carbonaware.sci;
+
+public interface EmbodiedEmissionsProvider {
+
+    double getEmbodiedEmissions();
+
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/EnergyConsumptionProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/EnergyConsumptionProvider.java
@@ -1,0 +1,7 @@
+package com.carbonaware.sci;
+
+public interface EnergyConsumptionProvider {
+
+    double getEnergyConsumption();
+
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/HeuristicEnergyConsumptionProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/HeuristicEnergyConsumptionProvider.java
@@ -1,0 +1,17 @@
+package com.carbonaware.sci;
+
+import java.util.Random;
+
+public class HeuristicEnergyConsumptionProvider implements EnergyConsumptionProvider {
+
+
+    public HeuristicEnergyConsumptionProvider() {
+
+    }
+
+    @Override
+    public double getEnergyConsumption() {
+        // TODO: placeholder
+        return new Random().nextDouble() * 100;
+    }
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/MarginalEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/MarginalEmissionsProvider.java
@@ -1,0 +1,28 @@
+package com.carbonaware.sci;
+
+/*
+ * From the Software Carbon Intensity (SCI) specification: https://grnsft.org/sci
+ *
+ * The carbon intensity of electricity is a measure of how much carbon (CO2eq) emissions are produced per
+ * kilowatt-hour (kWh) of electricity consumed. This MUST be in grams of carbon per kilowatt hours (gCO2eq/kWh).
+ *
+ * Because this standard uses a consequential approach, marginal emissions rates MUST be used for electricity
+ * consumption. Location-based measures the grid carbon intensity of a regional balancing authority. From a developer
+ * perspective, only the location-based info is important for having an impact on reducing carbon emissions. This
+ * excludes market-based measures, and is distinct from 100% renewable energy claims.
+ *
+ * The only figure that matters if you’re trying to optimize the scheduling of your compute in real-time is the
+ * marginal emissions intensity. This is the emissions intensity of the marginal power plant which will be turned up if
+ * you schedule some compute (e.g. increase electricity demand from the grid) at that moment.
+ */
+public interface MarginalEmissionsProvider {
+
+    /**
+     * The carbon intensity of electricity is a measure of how much carbon (CO2eq) emissions are produced per
+     * kilowatt-hour (kWh) of electricity consumed. This MUST be in grams of carbon per kilowatt hours (gCO2eq/kWh).
+     *
+     * @return The marginal emissions at a given location in grams of carbon per kilowatt hours (gCO2eq/kWh).
+     */
+    double getMarginalEmissions();
+
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensity.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensity.java
@@ -1,0 +1,31 @@
+package com.carbonaware.sci;
+
+public class SoftwareCarbonIntensity {
+
+    private double energyConsumption;
+    private double marginalEmissions;
+    private double embodiedEmissions;
+
+    public SoftwareCarbonIntensity(double energyConsumption, double marginalEmissions, double embodiedEmissions) {
+        this.energyConsumption = energyConsumption;
+        this.marginalEmissions = marginalEmissions;
+        this.embodiedEmissions = embodiedEmissions;
+    }
+
+    public double getEnergyConsumption() {
+        return energyConsumption;
+    }
+
+    public double getMarginalEmissions() {
+        return marginalEmissions;
+    }
+
+    public double getEmbodiedEmissions() {
+        return embodiedEmissions;
+    }
+
+    public double getSoftwareCarbonIntensity() {
+        return (energyConsumption * marginalEmissions) + embodiedEmissions;
+    }
+
+}

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensityService.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensityService.java
@@ -1,0 +1,39 @@
+package com.carbonaware.sci;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * The Software Carbon Intensity (SCI) is a rate, carbon emissions per one unit of R. The equation used to calculate
+ * the SCI value of a software system is:
+ *
+ * SCI = ((E * I) + M) per R
+ */
+@Service
+public class SoftwareCarbonIntensityService {
+
+    // In the SCI spec, this provides the 'E' value
+    EnergyConsumptionProvider energyConsumptionProvider;
+
+    // In the SCI spec, this provides the 'I' value
+    MarginalEmissionsProvider marginalEmissionsProvider;
+
+    // In the SCI spec, this provides the 'M' value
+    EmbodiedEmissionsProvider embodiedEmissionsProvider;
+
+    public SoftwareCarbonIntensityService(
+            EnergyConsumptionProvider energyConsumptionProvider,
+            MarginalEmissionsProvider marginalEmissionsProvider,
+            EmbodiedEmissionsProvider embodiedEmissionsProvider) {
+        this.energyConsumptionProvider = energyConsumptionProvider;
+        this.marginalEmissionsProvider = marginalEmissionsProvider;
+        this.embodiedEmissionsProvider = embodiedEmissionsProvider;
+    }
+
+    public SoftwareCarbonIntensity getSoftwareCarbonIntensity() {
+        return new SoftwareCarbonIntensity(
+                energyConsumptionProvider.getEnergyConsumption(),
+                marginalEmissionsProvider.getMarginalEmissions(),
+                embodiedEmissionsProvider.getEmbodiedEmissions());
+    }
+
+}

--- a/carbon-aware-starter/src/test/java/com/carbonaware/sci/SoftwareCarbonIntensityServiceTest.java
+++ b/carbon-aware-starter/src/test/java/com/carbonaware/sci/SoftwareCarbonIntensityServiceTest.java
@@ -1,0 +1,6 @@
+package com.carbonaware.sci;
+
+
+class SoftwareCarbonIntensityServiceTest {
+
+}


### PR DESCRIPTION
**Work in Progress**

This is an implementation of the SCI computation with providers for the different components of the calculation. It exposes a new actuator endpoint `/actuator/carbon/sci` that pulls energy consumed, marginal emissions, and emboddied emissions and produces the SCI score.

At the moment, the implementation providers are:
- a MarginalEmissionsProvider coming from the carbon-aware-sdk client already present in the project
- a EmboddiedEmissionsProvider that pulls from the application properties or defaults to 0.0 (to ignore emboddied emissions or assume the hardware is carbon neutral)
- an EnergyConsumptionProvider that provides a random value.  This is intended to work towards a energy consumption value based on CPU+Memorry usage.