### PR TITLE
Update energy provider with CPU usage

### DIFF
--- a/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
@@ -5,6 +5,7 @@ import com.carbonaware.apis.CarbonEmissionsParams;
 import com.carbonaware.apis.DefaultCarbonEmissionsParams;
 import com.carbonaware.endpoint.CarbonAwareActuatorEndpoint;
 import com.carbonaware.sci.*;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,8 +45,8 @@ public class CarbonAwareAutoConfiguration {
     }
 
     @Bean
-    public EnergyConsumptionProvider energyConsumptionProvider() {
-        return new ResourceUtilizationEnergyConsumptionProvider();
+    public EnergyConsumptionProvider energyConsumptionProvider(MeterRegistry metricsRegistry) {
+        return new ResourceUtilizationEnergyConsumptionProvider(metricsRegistry);
     }
 
     @Bean

--- a/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
@@ -5,7 +5,6 @@ import com.carbonaware.apis.CarbonEmissionsParams;
 import com.carbonaware.apis.DefaultCarbonEmissionsParams;
 import com.carbonaware.endpoint.CarbonAwareActuatorEndpoint;
 import com.carbonaware.sci.*;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -46,7 +45,7 @@ public class CarbonAwareAutoConfiguration {
 
     @Bean
     public EnergyConsumptionProvider energyConsumptionProvider() {
-        return new HeuristicEnergyConsumptionProvider();
+        return new ResourceUtilizationEnergyConsumptionProvider();
     }
 
     @Bean

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
@@ -1,17 +1,53 @@
 package com.carbonaware.sci;
 
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.search.Search;
+import org.slf4j.Logger;
+
+import java.util.Collection;
 import java.util.Random;
 
 public class ResourceUtilizationEnergyConsumptionProvider implements EnergyConsumptionProvider {
 
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(ResourceUtilizationEnergyConsumptionProvider.class);
 
-    public ResourceUtilizationEnergyConsumptionProvider() {
+    private final MeterRegistry metricsRegistry;
 
+    // This is hard-coded for now, but could be pulled from system-specific models similar to the way MacOs' Activity
+    // Monitor does it in modern versions today.  See https://blog.mozilla.org/nnethercote/2015/08/26/what-does-the-os-x-activity-monitors-energy-impact-actually-measure/comment-page-1/#comment-46775
+    private final double cpuEnergyTax = 100.0;
+
+    public ResourceUtilizationEnergyConsumptionProvider(MeterRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
     }
 
     @Override
     public double getEnergyConsumption() {
-        // TODO: placeholder
-        return new Random().nextDouble() * 100;
+        // it's difficult to tell what kind of meter a metric is from the endpoint
+        metricsRegistry.forEachMeter(meter -> {
+            log.info("Found " + meter.getId() + " metric of type " + meter.getClass().getName());
+        });
+
+        // The process CPU usages is a percentage 0.0 - 1.0 of the systems processors, so we'll need to multiply this by
+        // the systems total processors to get a scalar value that will change when we reduce the CPUs provisioned to an
+        // application.
+        Gauge cpuUsageSearch = metricsRegistry.find("process.cpu.usage").gauge();
+        if (cpuUsageSearch == null) {
+            log.error("Unable to find process.cpu.usage metric, returning 0 for energy consumption");
+            return 0.0;
+        }
+
+        Gauge systemCpusAvailableSearch = metricsRegistry.find("system.cpu.count").gauge();
+        if (systemCpusAvailableSearch == null) {
+            log.error("Unable to find system.cpu.count metric, returning 0 for energy consumption");
+            return 0.0;
+        }
+
+        double processCpuUsagePercentage = cpuUsageSearch.value();
+        log.info("Current process CPU usage is: " + processCpuUsagePercentage);
+        double systemCpusAvailable = systemCpusAvailableSearch.value();
+        log.info("Total CPUs on system is: " + systemCpusAvailable);
+
+        return (processCpuUsagePercentage * systemCpusAvailable) * cpuEnergyTax;
     }
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/ResourceUtilizationEnergyConsumptionProvider.java
@@ -2,10 +2,10 @@ package com.carbonaware.sci;
 
 import java.util.Random;
 
-public class HeuristicEnergyConsumptionProvider implements EnergyConsumptionProvider {
+public class ResourceUtilizationEnergyConsumptionProvider implements EnergyConsumptionProvider {
 
 
-    public HeuristicEnergyConsumptionProvider() {
+    public ResourceUtilizationEnergyConsumptionProvider() {
 
     }
 


### PR DESCRIPTION
This change updates the (previously randomized) HeuristicEnergyConsumption provider to:

* name it more specifically on what it does and that it's a "Proxy" metric in the terminology used in articles I've been reading
* compute the score provided using the percentage of the system CPUs being used by this process with a configurable tax value

This isn't a great energy consumption provider for our SCI calculation because it's not sensitive to what kind of processors we're talking about and what the actual energy draw on that hardware might be.  It seems like a lot of the general energy testing (such as MacOs Activity Monitor and top commands) use CPU weighted heavily and then some other hardware metrics in this manner though.  It's not going to give us a good value of how much carbon this process is producing, but it'll at least provide the correct indication through the SCI value when we're making things better or worse.