### PR TITLE
Expose sci and emissions endpoint for prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ JRebel's [Java Technology Report](https://www.jrebel.com/blog/2021-java-technolo
 
 ## Quickstart
 
-Build the application docker containers and then start them up (along with the third-party collectors) with:
+Build the application docker containers :
 
-`./playground.sh && docker-compose up`
+`./playground.sh`
+
+Start the docker containers (along with the third-party collectors) with:
+
+`WATTTIME_CLIENT_USERNAME=<USERNAME> WATTTIME_CLIENT_PASSWORD==<PWD> docker-compose up -d --build`

--- a/carbon-aware-starter/pom.xml
+++ b/carbon-aware-starter/pom.xml
@@ -39,6 +39,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareAutoConfiguration.java
@@ -33,8 +33,8 @@ public class CarbonAwareAutoConfiguration {
     }
 
     @Bean
-    public CarbonAwareActuatorEndpoint endpoint(CarbonAwareSdkClient client, SoftwareCarbonIntensityService sciService) {
-        return new CarbonAwareActuatorEndpoint(client, sciService);
+    public CarbonAwareActuatorEndpoint endpoint(CarbonAwareSdkClient client, MeterRegistry registry, SoftwareCarbonIntensityService sciService) {
+        return new CarbonAwareActuatorEndpoint(client, registry, sciService);
     }
 
     @Bean
@@ -44,18 +44,21 @@ public class CarbonAwareAutoConfiguration {
         return new SoftwareCarbonIntensityService(energyConsumptionProvider, marginalEmissionsProvider, embodiedEmissionsProvider);
     }
 
+    @ConditionalOnMissingBean(EnergyConsumptionProvider.class)
     @Bean
     public EnergyConsumptionProvider energyConsumptionProvider(MeterRegistry metricsRegistry) {
         return new ResourceUtilizationEnergyConsumptionProvider(metricsRegistry);
     }
 
+    @ConditionalOnMissingBean(MarginalEmissionsProvider.class)
     @Bean
     public MarginalEmissionsProvider marginalEmissionsProvider(CarbonAwareSdkClient client) {
         return new CarbonAwareSdkMarginalEmissionsProvider(client);
     }
 
+    @ConditionalOnMissingBean(EmbodiedEmissionsProvider.class)
     @Bean
-    public EmbodiedEmissionsProvider embodiedEmissionsProvider() {
-        return new ConfiguredEmboddiedEmissionsProvider();
+    public EmbodiedEmissionsProvider embodiedEmissionsProvider(CarbonAwareProperties props) {
+        return new ConfiguredEmboddiedEmissionsProvider(props.getEmbodiedEmissions());
     }
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareProperties.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/config/CarbonAwareProperties.java
@@ -9,6 +9,8 @@ public class CarbonAwareProperties {
 
     private String location = "";
 
+    private double embodiedEmissions = 0.0;
+
     public String getEndpoint() {
         return endpoint;
     }
@@ -23,5 +25,13 @@ public class CarbonAwareProperties {
 
     public void setLocation(String location) {
         this.location = location;
+    }
+
+    public double getEmbodiedEmissions() {
+        return embodiedEmissions;
+    }
+
+    public void setEmbodiedEmissions(double embodiedEmissions) {
+        this.embodiedEmissions = embodiedEmissions;
     }
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/endpoint/CarbonAwareActuatorEndpoint.java
@@ -4,6 +4,8 @@ import com.carbonaware.apis.CarbonAwareSdkClient;
 import com.carbonaware.models.Emissions;
 import com.carbonaware.sci.SoftwareCarbonIntensity;
 import com.carbonaware.sci.SoftwareCarbonIntensityService;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,21 +17,32 @@ import java.util.List;
 public class CarbonAwareActuatorEndpoint {
 
     private CarbonAwareSdkClient client;
+    private MeterRegistry registry;
     private SoftwareCarbonIntensityService sciService;
 
-    public CarbonAwareActuatorEndpoint(CarbonAwareSdkClient client, SoftwareCarbonIntensityService sciService) {
+    public CarbonAwareActuatorEndpoint(CarbonAwareSdkClient client, MeterRegistry registry, SoftwareCarbonIntensityService sciService) {
         this.client = client;
+        this.registry = registry;
         this.sciService = sciService;
-    }
-
-    @GetMapping("/emissions")
-    public ResponseEntity<List<Emissions>> customEndPoint() {
-        return new ResponseEntity<>(client.emissionsForLocation(), HttpStatus.OK);
+        registerPrometheusEndpoints();
     }
 
     @GetMapping("/sci")
     public ResponseEntity<SoftwareCarbonIntensity> sciEndpoint() {
         return new ResponseEntity<>(sciService.getSoftwareCarbonIntensity(), HttpStatus.OK);
+    }
+
+    @GetMapping("/emissions")
+    public ResponseEntity<List<Emissions>> emissions() {
+        return new ResponseEntity<>(client.emissionsForLocation(), HttpStatus.OK);
+    }
+
+    private void registerPrometheusEndpoints() {
+        Gauge.builder("carbon.sci", () -> sciEndpoint().getBody().getSoftwareCarbonIntensity()).register(registry);
+        Gauge.builder("carbon.emissions", () -> {
+            List<Emissions> emissions = emissions().getBody();
+            return emissions.stream().map(e -> e.getRating()).findFirst().orElse(0.0);
+        }).register(registry);
     }
 
 }

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/ConfiguredEmboddiedEmissionsProvider.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/ConfiguredEmboddiedEmissionsProvider.java
@@ -1,13 +1,12 @@
 package com.carbonaware.sci;
 
-import org.springframework.beans.factory.annotation.Value;
-
 public class ConfiguredEmboddiedEmissionsProvider implements EmbodiedEmissionsProvider {
 
-    @Value("${spring.carbon-aware.emboddied-emissions:0.0}")
     private double embodiedEmissions;
 
-    public ConfiguredEmboddiedEmissionsProvider() {}
+    public ConfiguredEmboddiedEmissionsProvider(double embodiedEmissions) {
+        this.embodiedEmissions = embodiedEmissions;
+    }
 
     @Override
     public double getEmbodiedEmissions() {

--- a/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensityService.java
+++ b/carbon-aware-starter/src/main/java/com/carbonaware/sci/SoftwareCarbonIntensityService.java
@@ -1,14 +1,11 @@
 package com.carbonaware.sci;
 
-import org.springframework.stereotype.Service;
-
 /**
  * The Software Carbon Intensity (SCI) is a rate, carbon emissions per one unit of R. The equation used to calculate
  * the SCI value of a software system is:
  *
  * SCI = ((E * I) + M) per R
  */
-@Service
 public class SoftwareCarbonIntensityService {
 
     // In the SCI spec, this provides the 'E' value

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
   ## Application
 
   hello-service:
+    image: hello-service:v1
     build:
       dockerfile: Dockerfile
       context: ./examples/multiple-services/hello-service
@@ -83,6 +84,7 @@ services:
       - weatherServiceForecast_baseUrl=http://weather-service:8081
 
   weather-service:
+    image: weather-service:v1
     build:
       dockerfile: Dockerfile
       context: ./examples/multiple-services/weather-service

--- a/examples/multiple-services/hello-service/src/main/java/com/example/hello/SampleEmbodiedEmissions.java
+++ b/examples/multiple-services/hello-service/src/main/java/com/example/hello/SampleEmbodiedEmissions.java
@@ -1,0 +1,13 @@
+package com.example.hello;
+
+import com.carbonaware.sci.EmbodiedEmissionsProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SampleEmbodiedEmissions implements EmbodiedEmissionsProvider {
+
+    @Override
+    public double getEmbodiedEmissions() {
+        return 10.0;
+    }
+}

--- a/playground.sh
+++ b/playground.sh
@@ -8,6 +8,7 @@ mkdir temp
 cd temp
 git clone https://github.com/Green-Software-Foundation/carbon-aware-sdk.git
 cd carbon-aware-sdk
+git checkout v1.0.0
 cd ./$(git rev-parse --show-cdup)/src
 docker build -t carbon_aware:v1 -f CarbonAware.WebApi/src/Dockerfile .
 cd $SCRIPT_DIR


### PR DESCRIPTION
This PR is responsible for the following :

1. Exposing sci and emissions endpoint for Prometheus to fetch data.
2. Refactor to conditionally create beans for EnergyConsumptionProvider, MarginalEmissionsProvider and EmbodiedEmissionsProvider only when an implementation is not provided. 
3. Added an implementation of EmbodiedEmissionsProvider in hello-service for testing point 2.
4. Update playground.sh to refer to tag v1.0.0 of carbon-aware-sdk